### PR TITLE
Facilities now display the animal and the number of in each facility when adding an animal

### DIFF
--- a/src/Actions/ChooseChickenHouse.cs
+++ b/src/Actions/ChooseChickenHouse.cs
@@ -15,6 +15,9 @@ namespace Trestlebridge.Actions
             for (int i = 0; i < farm.ChickenHouses.Count; i++)
             {
                 Console.WriteLine($"{i + 1} Chicken House has ({farm.ChickenHouses[i].animalCount}/{farm.ChickenHouses[i].Capacity})");
+                System.Console.WriteLine();
+                farm.GrazingFields[i].GroupedAnimals();
+                System.Console.WriteLine();
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseChickenHouse.cs
+++ b/src/Actions/ChooseChickenHouse.cs
@@ -16,7 +16,7 @@ namespace Trestlebridge.Actions
             {
                 Console.WriteLine($"{i + 1} Chicken House has ({farm.ChickenHouses[i].animalCount}/{farm.ChickenHouses[i].Capacity})");
                 System.Console.WriteLine();
-                farm.GrazingFields[i].GroupedAnimals();
+                farm.ChickenHouses[i].GroupedAnimals();
                 System.Console.WriteLine();
             }
 

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -16,7 +16,7 @@ namespace Trestlebridge.Actions
             {
                 Console.WriteLine($"{i + 1}. Duck House has ({farm.DuckHouses[i].animalCount}/{farm.DuckHouses[i].Capacity})");
                 System.Console.WriteLine();
-                farm.GrazingFields[i].GroupedAnimals();
+                farm.DuckHouses[i].GroupedAnimals();
                 System.Console.WriteLine();
             }
 

--- a/src/Actions/ChooseDuckHouse.cs
+++ b/src/Actions/ChooseDuckHouse.cs
@@ -15,6 +15,9 @@ namespace Trestlebridge.Actions
             for (int i = 0; i < farm.DuckHouses.Count; i++)
             {
                 Console.WriteLine($"{i + 1}. Duck House has ({farm.DuckHouses[i].animalCount}/{farm.DuckHouses[i].Capacity})");
+                System.Console.WriteLine();
+                farm.GrazingFields[i].GroupedAnimals();
+                System.Console.WriteLine();
             }
 
             Console.WriteLine();

--- a/src/Actions/ChooseGrazingField.cs
+++ b/src/Actions/ChooseGrazingField.cs
@@ -15,6 +15,9 @@ namespace Trestlebridge.Actions
             for (int i = 0; i < farm.GrazingFields.Count; i++)
             {
                 Console.WriteLine($"{i + 1}. Grazing Field has ({farm.GrazingFields[i].animalCount}/{farm.GrazingFields[i].Capacity})");
+                System.Console.WriteLine();
+                farm.GrazingFields[i].GroupedAnimals();
+                System.Console.WriteLine();
             }
 
             Console.WriteLine();

--- a/src/Models/Facilities/ChickenHouse.cs
+++ b/src/Models/Facilities/ChickenHouse.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Trestlebridge.Interfaces;
 
@@ -19,6 +20,17 @@ namespace Trestlebridge.Models.Facilities
             get
             {
                 return _capacity;
+            }
+        }
+
+        public void GroupedAnimals()
+        {
+            var collection = _animals.GroupBy(
+                animal => animal.Type
+            );
+            foreach (var animal in collection)
+            {
+                System.Console.WriteLine($"{animal.Count()} {animal.Key}(s)");
             }
         }
 

--- a/src/Models/Facilities/DuckHouse.cs
+++ b/src/Models/Facilities/DuckHouse.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Trestlebridge.Interfaces;
 
@@ -19,6 +20,17 @@ namespace Trestlebridge.Models.Facilities
             get
             {
                 return _capacity;
+            }
+        }
+
+        public void GroupedAnimals()
+        {
+            var collection = _animals.GroupBy(
+                animal => animal.Type
+            );
+            foreach (var animal in collection)
+            {
+                System.Console.WriteLine($"{animal.Count()} {animal.Key}(s)");
             }
         }
 

--- a/src/Models/Facilities/GrazingField.cs
+++ b/src/Models/Facilities/GrazingField.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Trestlebridge.Interfaces;
 
@@ -22,6 +23,16 @@ namespace Trestlebridge.Models.Facilities
             }
         }
 
+        public void GroupedAnimals()
+        {
+            var collection = _animals.GroupBy(
+                animal => animal.Type
+            );
+            foreach (var animal in collection)
+            {
+                System.Console.WriteLine($"{animal.Count()} {animal.Key}(s)");
+            }
+        }
         public void AddResource(IGrazing animal)
         {
             if (_animals.Count < Capacity)


### PR DESCRIPTION

# Description

Ticket#10 asked for facilities to display the animals and the amount of animals when adding an animal to a facility

Fixes # (issue)

Animals and number of needed to facilities when adding an animal to a facility

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# Testing Instructions

Added several animals to facilities to test to see if everything displays properly, Facilities will show the animals are inside of it and the amount of that animal already in it.
Press 1 when starting application to create a facility choose any of the fields of your liking, press 2 to purchase an animal then place into it's appropriate facility, create another animal by pressing 2 and it should display your previous animal in the facility now.



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or errors
- [x] I have added test instructions that prove my fix is effective or that my feature works
